### PR TITLE
/setupコマンドのBrewfile処理を改善

### DIFF
--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -25,15 +25,20 @@ pwd
 ```
 
 ### 2. Homebrew処理
-setup.shと同じロジック：
-- Homebrewがなければインストール
+Homebrewがインストールされていない場合のみ実行：
+- Homebrewのインストール
 - Xcode Command Line Toolsのチェック
 - エラー時は適切に対応
 
-### 3. Brewfile処理
-setup.shと同じロジック：
-- `~/.Brewfile`がなければコピー + `brew bundle --global`
-- あれば更新を確認
+### 3. Brewfileパッケージ処理
+
+1. **リポジトリのBrewfileから必要なパッケージを確認**
+2. **現在インストール済みのパッケージを確認** (`brew list`)
+3. **差分を表示**：
+   - 既にインストール済みのパッケージ
+   - 新規インストールが必要なパッケージ
+4. **ユーザーに確認**：「新規パッケージをインストールしますか？」
+5. **承認後に実行**：`brew install <パッケージ名>`
 
 ### 4. 設定ファイルの統合（zshrc, vimrc, gitconfig, gitignore_global）
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 # 既にリポジトリに含まれているが、今後の変更は追跡しない
 gitconfig-work
 gitconfig-other
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
/setupコマンドのBrewfile処理を実際のパッケージインストール状況ベースに改善しました。

## Problem
前回の実装では、Homebrewがインストール済みの場合にBrewfile処理全体をスキップしてしまい、必要なパッケージ（zsh-completions等）がインストールされませんでした。

## Changes
- Brewfileファイルの有無ではなく、**実際のパッケージインストール状況**を確認
- リポジトリのBrewfileと現在の状態を比較
- 差分を明示してユーザーの合意を得てからインストール

## Additional
- `.gitignore`に`.claude/settings.local.json`を追加

## Test plan
- [ ] /setupコマンドでBrewfileパッケージの差分が正しく表示されるか確認
- [ ] 新規パッケージのインストールが正しく動作するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>