### PR TITLE
fix: gitwtスクリプトとzshrcの問題を修正

### DIFF
--- a/gitwt/bin/gitwt-add
+++ b/gitwt/bin/gitwt-add
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/bash
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:$PATH"
 # gitwt-add: Create branch and worktree
 # Usage: gitwt-add <branch> [base]
 

--- a/gitwt/bin/gitwt-ls
+++ b/gitwt/bin/gitwt-ls
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/bash
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:$PATH"
 # gitwt-ls: List all worktrees
 # Usage: gitwt-ls
 

--- a/gitwt/bin/gitwt-path
+++ b/gitwt/bin/gitwt-path
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/bash
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:$PATH"
 # gitwt-path: Output worktree path for a branch
 # Usage: gitwt-path <branch>
 

--- a/gitwt/bin/gitwt-prune
+++ b/gitwt/bin/gitwt-prune
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/bash
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:$PATH"
 # gitwt-prune: Clean up orphaned worktrees and empty directories
 # Usage: gitwt-prune
 

--- a/gitwt/bin/gitwt-rm
+++ b/gitwt/bin/gitwt-rm
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/bash
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:$PATH"
 # gitwt-rm: Remove worktree and optionally branch
 # Usage: gitwt-rm <branch>
 

--- a/gitwt/bin/gitwt-root
+++ b/gitwt/bin/gitwt-root
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/bash
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:$PATH"
 # gitwt-root: Get the original repository root path
 # Usage: gitwt-root
 

--- a/zshrc
+++ b/zshrc
@@ -93,8 +93,10 @@ git_prompt() {
 }
 
 # precmd関数を安全に追加(他のプラグインと競合しないように)
+precmd_functions=(${precmd_functions:#add_newline})
 precmd_functions+=(add_newline)
 # git_prompt を有効化する場合は以下のコメントを解除
+# precmd_functions=(${precmd_functions:#git_prompt})
 # precmd_functions+=(git_prompt)
 
 #######


### PR DESCRIPTION
## Summary

gitwtスクリプトとzshrcで発生していた2つの問題を修正しました。

### 1. gitwtスクリプトのPATH解決問題

**問題:**
- wtgo/wtback関数からサブシェルでgitwtスクリプトを実行する際、envやdirnameなどの基本コマンドがPATHで解決できず失敗

**修正内容:**
- shebangを`#!/usr/bin/env bash`から`#!/bin/bash`に変更
- 各スクリプトにPATH設定を明示的に追加

**対象ファイル:**
- gitwt/bin/gitwt-add
- gitwt/bin/gitwt-ls
- gitwt/bin/gitwt-path
- gitwt/bin/gitwt-prune
- gitwt/bin/gitwt-rm
- gitwt/bin/gitwt-root

### 2. precmd_functions重複による余分な改行

**問題:**
- `source ~/.zshrc`を複数回実行すると、add_newline関数がprecmd_functionsに重複して追加され、余分な改行が出力される

**修正内容:**
- 既存の重複を削除してから追加することで、何度sourceしても常に1つだけになるよう改善

**対象ファイル:**
- zshrc

## Test plan

- [x] wtgo/wtback関数が正しく動作することを確認
- [x] 複数回source実行しても改行が1つだけであることを確認

Co-Authored-By: Claude <noreply@anthropic.com>