### PR TITLE
fix: wtgo/wtback関数でlocal path変数がPATHを壊す問題を修正

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -37,14 +37,14 @@ alias lla="ls -la"
 # gitwt (Git worktree management)
 #######
 wtgo() {
-  local path
-  path=$(gitwt-path "$1") || return $?
-  [[ -n "$path" ]] && cd "$path"
+  local wt_path
+  wt_path=$(gitwt-path "$1") || return $?
+  [[ -n "$wt_path" ]] && cd "$wt_path"
 }
 wtback() {
-  local path
-  path=$(gitwt-root) || return $?
-  [[ -n "$path" ]] && cd "$path"
+  local wt_path
+  wt_path=$(gitwt-root) || return $?
+  [[ -n "$wt_path" ]] && cd "$wt_path"
 }
 
 #######


### PR DESCRIPTION
## Summary

wtgo/wtback関数内で`local path`変数を使用していたことにより、zshの特別な変数`path`がローカル化され、PATH環境変数との関連が壊れる問題を修正しました。

## 問題

### 症状
- wtgo/wtback関数内でgitwt-pathコマンドが見つからない
- `which gitwt-path`では見つかるが、関数内では`command not found`エラー
- サブシェル`()`では成功するが、コマンド置換`$()`では失敗

### 根本原因

zshでは`path`変数が`PATH`環境変数と双方向同期される特別な変数です。

`local path`を宣言すると:
1. 関数スコープ内で`path`がローカル化される
2. `PATH`環境変数との関連が壊れる
3. コマンド置換内でPATH解決ができなくなる

## 修正内容

変数名を`path`から`wt_path`に変更:

```bash
# 修正前
wtgo() {
  local path
  path=$(gitwt-path "$1") || return $?
  [[ -n "$path" ]] && cd "$path"
}

# 修正後
wtgo() {
  local wt_path
  wt_path=$(gitwt-path "$1") || return $?
  [[ -n "$wt_path" ]] && cd "$wt_path"
}
```

## Test plan

- [x] wtgo関数が正しく動作することを確認
- [x] wtback関数が正しく動作することを確認
- [x] コマンド置換内でgitwt-pathが正しく解決されることを確認

Co-Authored-By: Claude <noreply@anthropic.com>